### PR TITLE
Bug fix in libraries/assets.php configure() function.

### DIFF
--- a/libraries/assets.php
+++ b/libraries/assets.php
@@ -600,7 +600,7 @@ class Assets {
 	 */
 	public function configure($cfg = null)
 	{
-		$cfg = array_merge($cfg, config_item('assets'));
+		$cfg = array_merge(config_item('assets'), $cfg);
 		
 		if ($cfg and is_array($cfg))
 		{


### PR DESCRIPTION
The array_merge variables were the wrong order -- new configuration options in $cfg were always overridden by options in config. Fixed now.
