### PR TITLE
Allow user to specify whether to echo JS and CSS tags

### DIFF
--- a/helpers/assets_helper.php
+++ b/helpers/assets_helper.php
@@ -10,27 +10,27 @@
  */
 
 
-function assets_css($assets = null, $attributes = null)
+function assets_css($assets = null, $attributes = null, $echo = true)
 {
-	Assets::css($assets, $attributes);
+	Assets::css($assets, $attributes, $echo);
 }
 
 
-function assets_css_group($group = null, $assets = null, $attributes = null)
+function assets_css_group($group = null, $assets = null, $attributes = null, $echo = true)
 {
-	Assets::css_group($group, $assets, $attributes);
+	Assets::css_group($group, $assets, $attributes, $echo);
 }
 
 
-function assets_js($assets = null)
+function assets_js($assets = null, $echo = true)
 {
-	Assets::js($assets);
+	Assets::js($assets, $echo);
 }
 
 
-function assets_js_group($group = null, $assets = null)
+function assets_js_group($group = null, $assets = null, $echo = true)
 {
-	Assets::js_group($group, $assets);
+	Assets::js_group($group, $assets, $echo);
 }
 
 
@@ -46,9 +46,9 @@ function assets_img($path = null, $tag = false, $properties = null)
 }
 
 
-function assets_cdn($assets = null)
+function assets_cdn($assets = null, $echo = true)
 {
-	Assets::cdn($assets);
+	Assets::cdn($assets, $echo);
 }
 
 

--- a/libraries/assets.php
+++ b/libraries/assets.php
@@ -70,9 +70,11 @@ class Assets {
 	/**
 	 * Display CSS tags
 	 * @param  array  $files
+	 * @param  array  $attributes
+	 * @param  bool   $echo
 	 * @return string
 	 */
-	public static function css($files = null, $attributes = null)
+	public static function css($files = null, $attributes = null, $echo = true)
 	{
 		self::init();
 
@@ -91,7 +93,7 @@ class Assets {
 		if (self::$_enable_benchmark) self::$_ci->benchmark->mark("Assets::css()_end");
 
 		// Tags
-		return self::_generate_tags('css');
+		return self::_generate_tags('css', $echo);
 	}
 
 	
@@ -101,9 +103,11 @@ class Assets {
 	 * Display a group of CSS tags
 	 * @param  string $group
 	 * @param  array  $files
+	 * @param  array  $attributes
+	 * @param  bool   $echo
 	 * @return string
 	 */
-	public static function css_group($group = null, $files = null, $attributes = null)
+	public static function css_group($group = null, $files = null, $attributes = null, $echo = true)
 	{
 		self::$group = $group;
 
@@ -123,7 +127,7 @@ class Assets {
 		if (self::$_enable_benchmark) self::$_ci->benchmark->mark("Assets::css_group(".$group.")_end");
 
 		// Tags
-		return self::_generate_tags('css');
+		return self::_generate_tags('css', $echo);
 	}
 
 	
@@ -132,9 +136,10 @@ class Assets {
 	/**
 	 * Display JS tags
 	 * @param  array  $files
+	 * @param  bool   $echo
 	 * @return string
 	 */
-	public static function js($files = null)
+	public static function js($files = null, $echo = true)
 	{
 		self::$group = null;
 
@@ -154,7 +159,7 @@ class Assets {
 		if (self::$_enable_benchmark) self::$_ci->benchmark->mark("Assets::js()_end");
 
 		// Tags
-		return self::_generate_tags('js');
+		return self::_generate_tags('js', $echo);
 	}
 
 	
@@ -164,9 +169,10 @@ class Assets {
 	 * Display a group of JS tags
 	 * @param  string $group
 	 * @param  array  $files
+	 * @param  bool   $echo
 	 * @return string
 	 */
-	public static function js_group($group = null, $files = null)
+	public static function js_group($group = null, $files = null, $echo = true)
 	{
 		self::$group = $group;
 
@@ -186,7 +192,7 @@ class Assets {
 		if (self::$_enable_benchmark) self::$_ci->benchmark->mark("Assets::js_group(".$group.")_end");
 
 		// Tags
-		return self::_generate_tags('js');
+		return self::_generate_tags('js', $echo);
 	}
 
 	


### PR DESCRIPTION
Hi,

I noticed that _generate_tags() has the option to either return or echo tags, but js(), js_group(), css() and css_group() don't, so I added the ability to specify whether to echo tags for those functions. I find this pretty handy when I don't directly use Assets in my views.

Thanks for the awesome project!
