### PR TITLE
_sass_loaded was not being set

### DIFF
--- a/libraries/assets.php
+++ b/libraries/assets.php
@@ -1174,6 +1174,7 @@ class Assets {
 
 			// Initialize
 			self::$_sass = new SassParser( $options );
+			self::$_sass_loaded = true;
 
 			// End benchmark
 			if (self::$_enable_benchmark) self::$_ci->benchmark->mark("Assets::init_sass()_end");


### PR DESCRIPTION
My oversight, $_sass_loaded was not being set causing a fatal error when multiple scss/sass files were included. Fixed.
