### PR TITLE
Added port support to images url generation

### DIFF
--- a/libraries/assets.php
+++ b/libraries/assets.php
@@ -635,10 +635,9 @@ class Assets {
 						elseif ($part != "") $parts[] = $part;
 					}
 
-					$new_href = ((array_key_exists('scheme', $base_parsed)) ? $base_parsed['scheme'] . '://' . $base_parsed['host'] : "") . "/" . implode("/", $parts);
+					$new_href = ((array_key_exists('scheme', $base_parsed)) ? $base_parsed['scheme'] . '://' . $base_parsed['host'] : "") . (array_key_exists('port', $base_parsed) ? ":".$base_parsed['port'] : '') . "/" . implode("/", $parts);
 					if (substr($path, 0, 2) == '//' and substr($new_href, 0, 2) != '//' and substr($new_href, 0, 1) == '/') $new_href = '/' . $new_href;
 				}
-
 				$contents = str_replace($href, $new_href, $contents);
 			}
 		}


### PR DESCRIPTION
Some people use different server ports in devel environment. For example MAMP, the famous mac 'lamp' app, uses :8888 as default.

The current version of lib don't support that on the url() replacement function. This pull add this functionality,
